### PR TITLE
button: set layer type software

### DIFF
--- a/loadingbutton/src/main/java/com/kusu/loadingbutton/LoadingButton.java
+++ b/loadingbutton/src/main/java/com/kusu/loadingbutton/LoadingButton.java
@@ -174,6 +174,7 @@ public class LoadingButton extends AppCompatButton implements View.OnTouchListen
             unpressedDrawable = createDrawable(mCornerRadius, disabledColor, Color.TRANSPARENT);
         }
         updateBackground(unpressedDrawable);
+        setLayerType(LAYER_TYPE_SOFTWARE,null);
         //Set padding
         this.setPadding(mPaddingLeft, mPaddingTop + mShadowHeight, mPaddingRight, mPaddingBottom + mShadowHeight);
     }


### PR DESCRIPTION
fixes crash on android emulator

```
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x98
Cause: null pointer dereference

    #00 pc 000934f7  /system/lib/libhwui.so (android::uirenderer::RecordingCanvas::refPaint(SkPaint const*)+263)
    #01 pc 00094efa  /system/lib/libhwui.so (android::uirenderer::RecordingCanvas::drawArc(float, float, float, float, float, float, bool, SkPaint const&)+154)
    #02 pc 000f89aa  /system/lib/libandroid_runtime.so (android::CanvasJNI::drawArc(_JNIEnv*, _jobject*, long long, float, float, float, float, float, float, unsigned char, long long)+122)
    #03 pc 012507ae  /system/framework/x86/boot-framework.oat (offset 0x606000) (android.view.RecordingCanvas.nDrawArc+286)
```